### PR TITLE
Corrected from double quotes to single quotes.

### DIFF
--- a/cypress/integration/HomeworkTests/calculator.spec.js
+++ b/cypress/integration/HomeworkTests/calculator.spec.js
@@ -3,21 +3,21 @@
 import Calculator from '../../page_objects/calculator.js'
 var calculator = new Calculator()
 
-beforeEach("executes before each test",()=>{
+beforeEach('executes before each test',()=>{
     cy.visit(Cypress.env('calculator_url'))
 })
 
 describe('should do addition using every build version', () => {
     ['Prototype','1', '2', '3', '4', '5', '6','7','8','9'].forEach((buildVersion) => {
         
-        it("does addition with empty values using build: " + buildVersion, ()=>{
+        it('does addition with empty values using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getOperationDropdown().select('Add');
             calculator.clickCalculateButton();
             calculator.getAnswerField().should('have.value', '0');
         })
         
-        it.only("does addition with invalid first value and clears error message using build: " + buildVersion, ()=>{       
+        it.only('does addition with invalid first value and clears error message using build: ' + buildVersion, ()=>{       
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type(',');
             calculator.getSecondNumberField().type('5');
@@ -26,10 +26,10 @@ describe('should do addition using every build version', () => {
             calculator.getAnswerField().should('have.value', '');
             calculator.getErrorMessage().contains('Number 1 is not a number');
             calculator.clickClearButton();
-            calculator.getErrorMessage().should("not.be.visible");
+            calculator.getErrorMessage().should('not.be.visible');
         })
         
-        it("does addition with positive integer values and clears the answer using build: " + buildVersion, ()=>{
+        it('does addition with positive integer values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('1.1');
             calculator.getSecondNumberField().type('2');
@@ -45,7 +45,7 @@ describe('should do addition using every build version', () => {
             calculator.getAnswerField().should('have.value', '3.1');
         })
         
-        it("does addition with negative integer values and clears the answer using build: " + buildVersion, ()=>{
+        it('does addition with negative integer values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('-1.1');
             calculator.getSecondNumberField().type('-2');
@@ -67,14 +67,14 @@ describe('should do addition using every build version', () => {
 describe('should do subtraction using every build version', () => {
     ['Prototype','1', '2', '3', '4', '5', '6','7','8','9'].forEach((buildVersion) => {
         
-        it("does subtraction with empty values using build: " + buildVersion, ()=>{
+        it('does subtraction with empty values using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getOperationDropdown().select('Subtract');
             calculator.clickCalculateButton();
             calculator.getAnswerField().should('have.value', '0');
         })
         
-        it("does subtraction with invalid first value and clears error message using build: " + buildVersion, ()=>{       
+        it('does subtraction with invalid first value and clears error message using build: ' + buildVersion, ()=>{       
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type(',');
             calculator.getSecondNumberField().type('5');
@@ -83,10 +83,10 @@ describe('should do subtraction using every build version', () => {
             calculator.getAnswerField().should('have.value', '');
             calculator.getErrorMessage().contains('Number 1 is not a number');
             calculator.clickClearButton();
-            calculator.getErrorMessage().should("not.be.visible")
+            calculator.getErrorMessage().should('not.be.visible')
         })
         
-        it("does subtraction with positive integer values and clears the answer using build: " + buildVersion, ()=>{
+        it('does subtraction with positive integer values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('4.5');
             calculator.getSecondNumberField().type('2');
@@ -102,7 +102,7 @@ describe('should do subtraction using every build version', () => {
             calculator.getAnswerField().should('have.value', '2.5');
         })
         
-        it.only("does subtraction with negative integer values and clears the answer using build: " + buildVersion, ()=>{
+        it.only('does subtraction with negative integer values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('-4.5');
             calculator.getSecondNumberField().type('-2');
@@ -124,14 +124,14 @@ describe('should do subtraction using every build version', () => {
 describe('should do multiplication using every build version', () => {
     ['Prototype','1', '2', '3', '4', '5', '6','7','8','9'].forEach((buildVersion) => {
         
-        it("does multiplication with empty values using build: " + buildVersion, ()=>{
+        it('does multiplication with empty values using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getOperationDropdown().select('Multiply');
             calculator.clickCalculateButton();
             calculator.getAnswerField().should('have.value', '0');
         })
         
-        it("does multiplication with invalid first value and clears error message using build: " + buildVersion, ()=>{       
+        it('does multiplication with invalid first value and clears error message using build: ' + buildVersion, ()=>{       
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type(',');
             calculator.getSecondNumberField().type('5');
@@ -140,10 +140,10 @@ describe('should do multiplication using every build version', () => {
             calculator.getAnswerField().should('have.value', '');
             calculator.getErrorMessage().contains('Number 1 is not a number');
             calculator.clickClearButton();
-            calculator.getErrorMessage().should("not.be.visible");
+            calculator.getErrorMessage().should('not.be.visible');
         })
         
-        it("does multiplication with zero using build: " + buildVersion, ()=>{
+        it('does multiplication with zero using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('0');
             calculator.getSecondNumberField().type('2.11');
@@ -157,7 +157,7 @@ describe('should do multiplication using every build version', () => {
             calculator.getAnswerField().should('have.value', '0');
         })
         
-        it.only("does multiplication with positive integer values and clears the answer using build: " + buildVersion, ()=>{
+        it.only('does multiplication with positive integer values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('1.1');
             calculator.getSecondNumberField().type('2');
@@ -173,7 +173,7 @@ describe('should do multiplication using every build version', () => {
             calculator.getAnswerField().should('have.value', '2.2');
         })
         
-        it("does multiplication with negative integer values and clears the answer using build: " + buildVersion, ()=>{
+        it('does multiplication with negative integer values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('-1.1');
             calculator.getSecondNumberField().type('-2');
@@ -195,7 +195,7 @@ describe('should do multiplication using every build version', () => {
 describe('should do division using every build version', () => {
     ['Prototype','1', '2', '3', '4', '5', '6','7','8','9'].forEach((buildVersion) => {
         
-        it("does division with empty values using build: " + buildVersion, ()=>{
+        it('does division with empty values using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getOperationDropdown().select('Divide');
             calculator.clickCalculateButton();
@@ -203,7 +203,7 @@ describe('should do division using every build version', () => {
             calculator.getErrorMessage().contains('Divide by zero error!');
         })
         
-        it("does division with invalid first value and clears error message using build: " + buildVersion, ()=>{       
+        it('does division with invalid first value and clears error message using build: ' + buildVersion, ()=>{       
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type(',');
             calculator.getSecondNumberField().type('5');
@@ -212,10 +212,10 @@ describe('should do division using every build version', () => {
             calculator.getAnswerField().should('have.value', '');
             calculator.getErrorMessage().contains('Number 1 is not a number');
             calculator.clickClearButton();
-            calculator.getErrorMessage().should("not.be.visible");
+            calculator.getErrorMessage().should('not.be.visible');
         })
         
-        it.only("does division by zero using build: " + buildVersion, ()=>{
+        it.only('does division by zero using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('1.5');
             calculator.getSecondNumberField().type('0');
@@ -225,7 +225,7 @@ describe('should do division using every build version', () => {
             calculator.getErrorMessage().contains('Divide by zero error!');
         })
         
-        it("does division with positive integer values and clears the answer using build: " + buildVersion, ()=>{
+        it('does division with positive integer values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('2.4');
             calculator.getSecondNumberField().type('2');
@@ -241,7 +241,7 @@ describe('should do division using every build version', () => {
             calculator.getAnswerField().should('have.value', '1.2');
         })
         
-        it("does division with negative integer values and clears the answer using build: " + buildVersion, ()=>{
+        it('does division with negative integer values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('-4.5');
             calculator.getSecondNumberField().type('-2');
@@ -263,7 +263,7 @@ describe('should do division using every build version', () => {
 describe('should do concatenation using every build version', () => {
     ['Prototype','1', '2', '3', '4', '5', '6','7','8','9'].forEach((buildVersion) => {
         
-        it("does concatenation with empty values using build: " + buildVersion, ()=>{
+        it('does concatenation with empty values using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getOperationDropdown().select('Concatenate');
             calculator.getIntegersCheckbox().should('not.be.visible');
@@ -271,7 +271,7 @@ describe('should do concatenation using every build version', () => {
             calculator.getAnswerField().should('have.value', '');
         })
         
-        it.only("does concatenation with invalid values and clears the answer using build: " + buildVersion, ()=>{
+        it.only('does concatenation with invalid values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('0.1.0');
             calculator.getSecondNumberField().type('2,11');
@@ -279,12 +279,12 @@ describe('should do concatenation using every build version', () => {
             calculator.getIntegersCheckbox().should('not.be.visible');
             calculator.clickCalculateButton();
             calculator.getAnswerField().should('have.value', '0.1.02,11');
-            calculator.getErrorMessage().should("not.be.visible");
+            calculator.getErrorMessage().should('not.be.visible');
             calculator.clickClearButton();
             calculator.getAnswerField().should('have.value', '');
         })
         
-        it("does concatenation with negative values and clears the answer using build: " + buildVersion, ()=>{
+        it('does concatenation with negative values and clears the answer using build: ' + buildVersion, ()=>{
             calculator.getBuildDropdown().select(buildVersion);
             calculator.getFirstNumberField().type('-1.1');
             calculator.getSecondNumberField().type('-2');


### PR DESCRIPTION
Corrected from double quotes to single quotes, except for the first line, because that way it was used in cypress examples.